### PR TITLE
fix: restrict edit and delete options for GPS and HamD records to Adm…

### DIFF
--- a/patient/templates/patient_detailed.html
+++ b/patient/templates/patient_detailed.html
@@ -317,12 +317,14 @@
 														{{ GPS_CE_score }} 
 													</td>
 													<td>
+														{% if group_type == "Admin" %}
 														<a href="{% url 'PatientUpdateGPS' GPS.pk %}" style="text-decoration:none; color: #6417A1">
 															<i class="fa-solid fa-pen-to-square"></i>
 														</a>
 														<a href="{% url 'PatientDeleteGPS' GPS.pk %}" style="text-decoration:none; color: red" onclick="return confirm('Are you sure you want to delete this record?');">
 															<i class="fa-solid fa-trash-can relative_remove_icon"></i>
 														</a>
+														{% endif %}
 													</td>
 												</tr>
 											{% empty %}
@@ -388,12 +390,14 @@
 														<b>{{ hamd.total_score }}</b>
 													</td>
 													<td>
-														<a href="{% url 'PatientUpdateHamD' hamd.pk %}" style="text-decoration:none; color: #6417A1">
-															<i class="fa-solid fa-pen-to-square"></i>
-														</a>
-														<a href="{% url 'PatientDeleteHamD' hamd.pk %}" style="text-decoration:none; color: red" onclick="return confirm('Are you sure you want to delete this record?');">
-															<i class="fa-solid fa-trash-can relative_remove_icon"></i>
-														</a>
+														{% if group_type == "Admin" %}
+															<a href="{% url 'PatientUpdateHamD' hamd.pk %}" style="text-decoration:none; color: #6417A1">
+																<i class="fa-solid fa-pen-to-square"></i>
+															</a>
+															<a href="{% url 'PatientDeleteHamD' hamd.pk %}" style="text-decoration:none; color: red" onclick="return confirm('Are you sure you want to delete this record?');">
+																<i class="fa-solid fa-trash-can relative_remove_icon"></i>
+															</a>
+														{% endif %}
 													</td>
 												</tr>
 												{% endif %}


### PR DESCRIPTION
This pull request implements access control restrictions for the GPS and HamD records:

    ✏️ Edit and 🗑 Delete options are now visible and functional only to Admin users.

    🚫 Non-admin users can no longer access or trigger these actions via UI or URL manipulation.

    🛡️ This helps enforce role-based permissions and prevent unauthorized modifications to sensitive data.